### PR TITLE
Fixed eigenlayer tests

### DIFF
--- a/foundry/test/exercise-eigen-layer.sol
+++ b/foundry/test/exercise-eigen-layer.sol
@@ -46,12 +46,14 @@ contract EigenLayerTest is Test {
 
     function test_deposit() public {
         // Test auth
-        vm.expectRevert();
+
         vm.prank(address(1));
-        restake.deposit(RETH_AMOUNT);
 
         uint256 shares = restake.deposit(RETH_AMOUNT);
         console.log("shares %e", shares);
+
+        vm.expectRevert();
+        restake.deposit(RETH_AMOUNT);
 
         assertGt(shares, 0);
         assertEq(


### PR DESCRIPTION
There was a error in the eigenlayer tests. The `vm.expectRevert()` was placed before the `vm.prank`  which made no sense as it was for the double deposit Error. I fixed it @t4sk do have a look. Thanks.